### PR TITLE
Require newer version of coding standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "jakub-onderka/php-console-highlighter": "^0.4.0",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "mockery/mockery": "^1.2.1",
-        "nicwortel/coding-standard": "^1.1.1",
+        "nicwortel/coding-standard": "^1.1.2",
         "phpstan/phpstan": "^0.11.12",
         "phpunit/phpunit": "^8.3",
         "symfony/framework-bundle": "^4.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,7 +5,7 @@
 
     <rule ref="vendor/nicwortel/coding-standard/ruleset.xml"/>
 
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
         <properties>
             <property name="enableObjectTypeHint" value="false"/>
         </properties>

--- a/src/Bundle/DependencyInjection/CommandPipelineExtension.php
+++ b/src/Bundle/DependencyInjection/CommandPipelineExtension.php
@@ -12,10 +12,7 @@ use function dirname;
 final class CommandPipelineExtension extends Extension
 {
     /**
-     * @param mixed[]          $configs
-     * @param ContainerBuilder $container
-     *
-     * @return void
+     * @param mixed[] $configs
      */
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/StagedPipeline.php
+++ b/src/StagedPipeline.php
@@ -21,8 +21,7 @@ final class StagedPipeline implements CommandPipeline
     private $logger;
 
     /**
-     * @param Stage[]         $stages
-     * @param LoggerInterface $logger
+     * @param Stage[] $stages
      */
     public function __construct(array $stages, LoggerInterface $logger)
     {


### PR DESCRIPTION
In `nicwortel/coding-standard:1.1.2` the `slevomat/coding-standard` package was updated from `5.0` to `6.0`. In that version the `TypeHintDeclarations` rule was removed and split up into several -more specific- rules. This broke our custom ruleset for PHPCS.

In this PR this is fixed by changing the requirement for `nicwortel/coding-standard` from `^1.1.1` to `1.1.2`. This way we can update our custom ruleset for PHPCS to assume the newest rules.

This caused us to be able to more specifically override the rule that was causing issues, resulting in some extra code standard fixes.