### PR TITLE
Add build for PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - '7.2'
   - '7.3'
+  - '7.4'
 
 services:
   - mysql

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,4 +10,10 @@
             <property name="enableObjectTypeHint" value="false"/>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
I am working on PHP 7.4 and my tests kept failing on the coding standards.
It seems that `slevomat/coding-standard:^6.0` used by `nicwortel/coding-standard` has some checks for PHP 7.4 (native property type hints), which only fail when using PHP 7.4.

Since this package is supporting `php:^7.2` i will look to override those checks to make the build pass.