### PR TITLE
Support lower version of doctrine-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "beberlei/assert": "^2.1|^3.0",
-        "doctrine/doctrine-bundle": "^2.0",
+        "beberlei/assert": "^2.1 || ^3.0",
+        "doctrine/doctrine-bundle": "^1.11 || ^2.0",
         "doctrine/orm": "^2.6.3",
         "psr/log": "^1.1",
         "simple-bus/message-bus": "^3.0",


### PR DESCRIPTION
The constraint for `doctrine/doctrine-bundle` was updated to `^2.0` in #3 but this is not required.
Also removed the single pipe syntax for dependency ranges as it is deprecated.