### PR TITLE
Update PHPstan to 0.12.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint: vendor
 	vendor/bin/parallel-lint src
 
 static-analysis: vendor
-	vendor/bin/phpstan analyse --level=7 src/
+	vendor/bin/phpstan analyse --level=8 src/
 
 unit-tests: vendor
 	vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "mockery/mockery": "^1.2.1",
         "nicwortel/coding-standard": "^1.1.2",
-        "phpstan/phpstan": "^0.11.12",
+        "phpstan/phpstan": "^0.12.7",
         "phpunit/phpunit": "^8.3",
         "symfony/framework-bundle": "^4.0"
     },

--- a/src/Validation/ValidationStage.php
+++ b/src/Validation/ValidationStage.php
@@ -51,6 +51,7 @@ final class ValidationStage implements Stage
     }
 
     /**
+     * @param ConstraintViolationListInterface<ConstraintViolationInterface> $violations
      * @return string[][]
      */
     private function normalizeViolations(ConstraintViolationListInterface $violations): array


### PR DESCRIPTION
After removing my `vendor` folder and `composer.lock` file, i could no longer install the dependencies with `composer install`. It seems that somehow there was a conflict (in a dependency of PHPstan) that went undetected by the build. I didn't take the time to figure this out since the error was resolved by updating PHPStan, which i think wont hurt.

- PHPstan has a new level. It has become level 6, shifting what were previously level 6 and 7 to 7 and 8.
- The new level checks for TypeHints, see: https://medium.com/@ondrejmirtes/phpstan-0-12-released-f1a88036535d#1d21